### PR TITLE
support to configure worker's option as false

### DIFF
--- a/lib/delayed/master/config.rb
+++ b/lib/delayed/master/config.rb
@@ -72,7 +72,7 @@ module Delayed
 
         SIMPLE_CONFIGS.each do |key|
           define_method(key) do |value = nil|
-            if value
+            if !value.nil?
               @data[key] = value
             else
               @data[key]


### PR DESCRIPTION
A configuration like, `worker.exit_on_complete false` is not working.
It cannot update as `false` since falsy values are ignored:
https://github.com/kanety/delayed_job_master/blob/master/lib/delayed/master/config.rb#L75-L76

Fix to assign a value except when it is `nil` exactly(intended right?).

Sorry for that I cannot add the test for it.

Signed-off-by: Hansuk <flavono123@gmail.com>